### PR TITLE
Fix t entries

### DIFF
--- a/fillpdf/fillpdfs.py
+++ b/fillpdf/fillpdfs.py
@@ -206,6 +206,10 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
                     pass
                 if target and annotation[SUBTYPE_KEY] == WIDGET_SUBTYPE_KEY:
                     key = target[ANNOT_FIELD_KEY][1:-1] # Remove parentheses
+                    target_aux = target
+                    while target_aux['/Parent']:  # ADDED to find mo keys that the library does not support
+                        key = target['/Parent'][ANNOT_FIELD_KEY][1:-1] + '.' + key
+                        target_aux = target_aux['/Parent']
                     if key in data_dict.keys():
                         if target[ANNOT_FORM_type] == ANNOT_FORM_button:
                             # button field i.e. a radiobuttons
@@ -227,6 +231,8 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
                                     options = []
                                     for each in annotation['/Kids']:
                                         keys2 = each['/AP']['/N'].keys()
+                                        if '/Off' in keys2:
+                                            keys2.remove('/Off')
                                         if ['/Off'] in keys:
                                             keys2.remove('/Off')
                                         export = keys2[0]

--- a/fillpdf/fillpdfs.py
+++ b/fillpdf/fillpdfs.py
@@ -207,7 +207,7 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
                 if target and annotation[SUBTYPE_KEY] == WIDGET_SUBTYPE_KEY:
                     key = target[ANNOT_FIELD_KEY][1:-1] # Remove parentheses
                     target_aux = target
-                    while target_aux['/Parent']:  # ADDED to find mo keys that the library does not support
+                    while target_aux['/Parent']:
                         key = target['/Parent'][ANNOT_FIELD_KEY][1:-1] + '.' + key
                         target_aux = target_aux['/Parent']
                     if key in data_dict.keys():


### PR DESCRIPTION
Folowing the ISO documentation
https://opensource.adobe.com/dc-acrobat-sdk-docs/standards/pdfstandards/pdf/PDF32000_2008.pdf

The T entry in the field dictionary (see Table 220) holds a text string defining the field’s partial field name. The fully qualified field name is not explicitly defined but shall be constructed from the partial field names of the field and all of its ancestors. For a field with no parent, the partial and fully qualified names are the same. For a field that is the child of another field, the fully qualified name shall be formed by appending the child field’s partial name to the parent’s fully qualified name, separated by a PERIOD (2Eh) as shown:

parent’s_full_name.child’s_partial_name

EXAMPLE If a field with the partial field name PersonalData has a child whose partial name is Address, which in turn has a child with the partial name ZipCode, the fully qualified name of this last field is PersonalData.Address.ZipCode.

So we need to find the full name of the key iterating all the parents annotations.

Also in the kids annotations the removal of the ['Off'] was not correct, i decided to add on if to remove also when off was in keys2 variable.
