### PR TITLE
Fix flattening process to allow for additional field format options

### DIFF
--- a/fillpdf.egg-info/SOURCES.txt
+++ b/fillpdf.egg-info/SOURCES.txt
@@ -12,3 +12,5 @@ fillpdf.egg-info/dependency_links.txt
 fillpdf.egg-info/entry_points.txt
 fillpdf.egg-info/requires.txt
 fillpdf.egg-info/top_level.txt
+fillpdf/utils/__init__.py
+fillpdf/utils/text_fields.py

--- a/fillpdf/fillpdfs.py
+++ b/fillpdf/fillpdfs.py
@@ -5,6 +5,7 @@ from pdf2image import convert_from_path # Needs conda install -c conda-forge pop
 from PIL import Image
 from collections import OrderedDict
 
+from fillpdf.utils.field_format import is_text_field_multiline, make_read_only
 ANNOT_KEY = '/Annots'               # key for all annotations within a page
 ANNOT_FIELD_KEY = '/T'              # Name of field. i.e. given ID of field
 ANNOT_FORM_type = '/FT'             # Form type (e.g. text/button)
@@ -291,7 +292,7 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
                             if target[ANNOT_FIELD_KIDS_KEY]:
                                 target[ANNOT_FIELD_KIDS_KEY][0].update( pdfrw.PdfDict( V=data_dict[key], AP=data_dict[key]) )
                 if flatten == True:
-                    annotation.update(pdfrw.PdfDict(Ff=1))
+                    annotation.update(pdfrw.PdfDict(Ff=make_read_only(target["/Ff"])))
     template_pdf.Root.AcroForm.update(pdfrw.PdfDict(NeedAppearances=pdfrw.PdfObject('true')))
     pdfrw.PdfWriter().write(output_pdf_path, template_pdf)
 

--- a/fillpdf/utils/field_format.py
+++ b/fillpdf/utils/field_format.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+
+def is_text_field_multiline(field_format: int) -> bool:
+  return "{0:b}".format(field_format)[-13] == 1
+
+def make_read_only(field_format: Optional[str]) -> int:
+  """
+  Returns a Read-Only version of a given field format.
+
+  According to the PDF specifications, the /Ff field is a 32-bit integer
+  defining multiple characteristics. The lowest bit defines a "read-only" field.
+
+  Parameters
+  ---------
+  field_format: Optional[str]
+      The field format for a given field.
+
+  Returns
+  ---------
+  """
+  if field_format is None:
+    return 1
+  else:
+    binary_field_format = "{0:b}".format(int(field_format))
+    read_only_field_format = binary_field_format[:-1] + "1"
+    return int(read_only_field_format, 2)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
 setup(
     name='fillpdf',
     packages=find_packages(exclude=['tests']),
-    version='0.7.2',
+    version='0.7.3',
     install_requires=install_requires,
     description='A Library to fill and flatten pdfs',
     long_description=long_description,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from fillpdf.utils.field_format import make_read_only
+
+# Given no test framework is currently defined, I just used some standard python
+
+def test_make_read_only_with_valid_field_format(fixture: str = "34325"):
+  read_only_field_format = make_read_only(fixture)
+  binary_field_format = "{0:b}".format(int(read_only_field_format))
+  assert binary_field_format.endswith("1")
+
+def test_make_read_only_with_empty_field_format(fixture: Optional[str] = None):
+  read_only_field_format = make_read_only(fixture)
+  binary_field_format = "{0:b}".format(int(read_only_field_format))
+  assert binary_field_format.endswith("1")


### PR DESCRIPTION
Several issues like #31 #39  are caused by the flattening process which is slightly too simplified. According to the PDF specifications, the field format ("/Ff") is a 32 bit integer where only the last bit is relevant to make a pdf read-only. By setting the entire field to 1 as is done [here](https://github.com/t-houssian/fillpdf/blob/5a4be9249dffc0ba0e347a3899732c14f88ef335/fillpdf/fillpdfs.py#L293-L294) we are losing out on quite a lot of functionality.

This patch fixes these issues by only setting the read-only bit to 1 and leaving all the other bits as they are.