### PR TITLE
write_fill_pdf flatten parameter now preserves multiline edit fields

### DIFF
--- a/fillpdf/fillpdfs.py
+++ b/fillpdf/fillpdfs.py
@@ -177,7 +177,7 @@ def convert_dict_values_to_string(dictionary):
     return res    
     
     
-def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False):
+def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False, fontinfo=None):
     """
     Writes the dictionary values to the pdf. Currently supports text and buttons.
     Does so by updating each individual annotation with the contents of the dat_dict.
@@ -192,6 +192,8 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
     flatten: bool
         Default is False meaning it will stay editable. True means the annotations
         will be uneditable.
+    fontinfo: str
+        Default is None to preserve template font. Example of fontinfo to change text fields: Arial 8.00 Tf 0 g
     Returns
     ---------
     """
@@ -199,6 +201,13 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
 
     template_pdf = pdfrw.PdfReader(input_pdf_path)
     flatten_mask = 1
+    if fontinfo:
+        PDF_TEXT_APPEARANCE = (
+            pdfrw.objects.pdfstring.PdfString.encode(
+                '/'+fontinfo 
+            )
+        )
+
     for Page in template_pdf.pages:
         if Page[ANNOT_KEY]:
             for annotation in Page[ANNOT_KEY]:
@@ -293,6 +302,8 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
                                 target[ANNOT_FIELD_KIDS_KEY][0].update( pdfrw.PdfDict( V=data_dict[key], AP=data_dict[key]) )
                             if int(target["/Ff"]) > 0:
                                 flatten_mask |= int(target["/Ff"])
+                            if fontinfo:
+                                target.update({"/DA": PDF_TEXT_APPEARANCE})
                 if flatten == True:
                     annotation.update(pdfrw.PdfDict(Ff=flatten_mask))
     template_pdf.Root.AcroForm.update(pdfrw.PdfDict(NeedAppearances=pdfrw.PdfObject('true')))

--- a/fillpdf/fillpdfs.py
+++ b/fillpdf/fillpdfs.py
@@ -198,6 +198,7 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
     data_dict = convert_dict_values_to_string(data_dict)
 
     template_pdf = pdfrw.PdfReader(input_pdf_path)
+    flatten_mask = 1
     for Page in template_pdf.pages:
         if Page[ANNOT_KEY]:
             for annotation in Page[ANNOT_KEY]:
@@ -290,8 +291,10 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
                             target.update( pdfrw.PdfDict( V=data_dict[key], AP=data_dict[key]) )
                             if target[ANNOT_FIELD_KIDS_KEY]:
                                 target[ANNOT_FIELD_KIDS_KEY][0].update( pdfrw.PdfDict( V=data_dict[key], AP=data_dict[key]) )
+                            if int(target["/Ff"]) > 0:
+                                flatten_mask |= int(target["/Ff"])
                 if flatten == True:
-                    annotation.update(pdfrw.PdfDict(Ff=1))
+                    annotation.update(pdfrw.PdfDict(Ff=flatten_mask))
     template_pdf.Root.AcroForm.update(pdfrw.PdfDict(NeedAppearances=pdfrw.PdfObject('true')))
     pdfrw.PdfWriter().write(output_pdf_path, template_pdf)
 


### PR DESCRIPTION
write_fill_pdf flatten option must set first bit of /Ff field but must preserve the other bits. 

Form fields with multiline option (bitmask 4096) where being transformed into single line by setting /Ff to 1, this patch preserves the Ff bit mask if fields any form field has multiple line bit set.

See https://stackoverflow.com/questions/68119744/python-how-to-properly-fill-a-multiline-text-field-in-pdf-form-using-pdfrw and https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.4.pdf, page 552 for a description of /Ff bitmask