### PR TITLE
Array fix where '/Off' is first element in array

### DIFF
--- a/fillpdf/fillpdfs.py
+++ b/fillpdf/fillpdfs.py
@@ -217,6 +217,9 @@ def write_fillable_pdf(input_pdf_path, output_pdf_path, data_dict, flatten=False
                             if not annotation['/T']:
                                 if annotation['/AP']:
                                     keys = annotation['/AP']['/N'].keys()
+                                    if '/off' == keys[0].lower():
+                                        keys.pop(0)
+                                        keys.append('/Off')
                                     if keys[0]:
                                         if keys[0][0] == '/':
                                             keys[0] = str(keys[0][1:])


### PR DESCRIPTION
Dear creators of fillpdf,

In your code, in the "write_fillable_pdf" function, it assumes that "/Off" is always the second element in the array and "/label_name" is the first, then you remove the "/" in the first element of the array to get "label_name" and compare whether there is an intersection with the target value for the key of this question, but there are cases where "/Off" is the first value in the array with "/label_name" and then after processing operations we will have such an array ["Off", "/label_name"] (in our case - ["Off", "/Uncertain"]) and we will look for an intersection with ["label_name"] (in our case ["Uncertain"]). It is obvious that it will not be found and one of the fields will not be filled, which is what happened in our form. So, this PR is a solution to this little problem in your wonderful library. Ready for your questions.

Best regards 
Petro.